### PR TITLE
Retry to get node name if it still = 'Loading...'

### DIFF
--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.js
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/js/innercontent.js
@@ -618,10 +618,11 @@ angular.module("umbraco.directives").directive("innerContentUnsavedChanges", [
 angular.module("umbraco").factory("innerContentService", [
 
     "$interpolate",
+    "$timeout",
     "localStorageService",
     "Our.Umbraco.InnerContent.Resources.InnerContentResources",
 
-    function ($interpolate, localStorageService, icResources) {
+    function ($interpolate, $timeout, localStorageService, icResources) {
 
         var self = {};
 
@@ -717,9 +718,18 @@ angular.module("umbraco").factory("innerContentService", [
                 itm.$index = idx;
 
                 // Execute the name expression
-                var newName = nameExp(itm);
-                if (newName && (newName = $.trim(newName)) && itm.name !== newName) {
-                    itm.name = newName;
+                var setName = function () {
+                    var newName = nameExp(itm);
+                    if (newName && (newName = $.trim(newName)) && itm.name !== newName) {
+                        itm.name = newName;
+                    }
+                };
+
+                setName();
+
+                // hacky attempt to make the asynchronous angularjs filters render the real name
+                if (contentType.nameTemplate.includes('ncNodeName') && itm.name === 'Loading...') {
+                    $timeout(setName, 500);
                 }
 
                 // Remove temporary index property


### PR DESCRIPTION
The ncNodeName filter makes an async call to get the node name and caches the result. As a result the name only displays on subsequent requests. Many times editors will not make a second request, so this attempts to make a better UX. 🤞 