### PR TITLE
Option to change the component's display name

### DIFF
--- a/src/Our.Umbraco.InnerContent/InnerContentConstants.cs
+++ b/src/Our.Umbraco.InnerContent/InnerContentConstants.cs
@@ -6,6 +6,8 @@
 
         internal const string ContentTypeGuidPropertyKey = "icContentTypeGuid";
 
+        internal const string ContentTypeNamePropertyKey = "icContentTypeName";
+
         internal const string PreValuesCacheKey = "Our.Umbraco.InnerContent.GetPreValuesCollectionByDataTypeId_{0}";
 
         internal const string ContentTypesPreValueKey = "contentTypes";

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/InnerContentPropertyValueEditor.cs
@@ -235,7 +235,8 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
                 || propKey == "key"
                 || propKey == "icon"
                 || propKey == InnerContentConstants.ContentTypeGuidPropertyKey
-                || propKey == InnerContentConstants.ContentTypeAliasPropertyKey;
+                || propKey == InnerContentConstants.ContentTypeAliasPropertyKey
+                || propKey == InnerContentConstants.ContentTypeNamePropertyKey;
         }
 
         #endregion

--- a/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
+++ b/src/Our.Umbraco.InnerContent/PropertyEditors/SimpleInnerContentPropertyValueEditor.cs
@@ -97,7 +97,9 @@ namespace Our.Umbraco.InnerContent.PropertyEditors
 
             if (token is JObject jObj)
             {
-                if (jObj[InnerContentConstants.ContentTypeGuidPropertyKey] != null || jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null)
+                if (jObj[InnerContentConstants.ContentTypeGuidPropertyKey] != null 
+                    || jObj[InnerContentConstants.ContentTypeAliasPropertyKey] != null
+                    || jObj[InnerContentConstants.ContentTypeNamePropertyKey] != null)
                 {
                     ConvertInnerContentDbToEditor(jObj, dataTypeService);
                 }

--- a/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.doctypepicker.html
+++ b/src/Our.Umbraco.InnerContent/Web/UI/App_Plugins/InnerContent/views/innercontent.doctypepicker.html
@@ -34,6 +34,9 @@
                         <span class="list-view-layout__system">({{ item.alias || 'alias' }})</span>
                     </div>
                     <div class="list-view-layout__path">
+                        <input type="text" ng-model="item.displayName" placeholder="display name..." class="-full-width-input" />
+                    </div>
+                    <div class="list-view-layout__path">
                         <input type="text" ng-model="item.nameTemplate" placeholder="name template..." class="-full-width-input" />
                     </div>
                     <div>


### PR DESCRIPTION
When working with many document types with subtle differences, it's not ideal to simply use the doctype name when displaying to the editor.

Ex. Say you have three gallery document types. The only difference is the media picker has a different starting folder. 
- Gallery (People) | media picker starts in the people directory
- Gallery (Nature) | media picker starts in the nature directory
- Gallery (Buildings) | media picker starts in the buildings directory

The editor will only be displayed one Gallery component option (depending on the node type they are working on). In this situation, the editor does not need to know what "type" of gallery they are creating. They are only seeing it, because that is the developer's naming convention. They simply need a "Gallery" component option.

This PR, makes overriding the name that is displayed.